### PR TITLE
Fix lineup modal close method

### DIFF
--- a/src/app/shared/components/team-lineup-modal/team-lineup-modal.component.ts
+++ b/src/app/shared/components/team-lineup-modal/team-lineup-modal.component.ts
@@ -70,7 +70,6 @@ export class TeamLineupModalComponent implements OnInit, OnDestroy {
 
   close() {
     this.visible.set(false);
-    this.visible.set(false);
   }
 
   //GERAR COMPARTILHAMENTO DOS TIMES


### PR DESCRIPTION
## Summary
- remove duplicate call in `close()` method of TeamLineupModalComponent

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d2096a80832bbdaa36cfce0591e4